### PR TITLE
Added a add alias command

### DIFF
--- a/plugin/conf/modules.scm
+++ b/plugin/conf/modules.scm
@@ -42,7 +42,7 @@
 
     (cond ((null? entries) #f)
           ((null? (cdr entries)) (car entries))
-          (else 
+          (else
            (choose-from-list "Symbol multiply declared" "Choose the module to require:" entries)))))
 
 
@@ -55,7 +55,7 @@
             (let* ((line   (offset-line point buffer))
                    (offset (line-offset line buffer)))
               (when (< offset point)
-                (try-finally 
+                (try-finally
                     (set! offset (line-offset (+ line 1) buffer))
                   #f))
               (insert-text (format #f "~a~a~%"  (if needs-newline-before "\n" "") insertion) offset buffer))))))))
@@ -64,7 +64,7 @@
 (define (find-best-require-insertion-point insertion buffer)
   (let* ((start (first-non-comment-line-offset buffer))
          (start (skip-module-headers buffer start)))
-    (skip-require-clauses buffer start insertion)))
+    (find-best-require-clause buffer start insertion)))
 
 
 (define (skip-module-headers buffer start)
@@ -78,7 +78,15 @@
           start))))
 
 
-(define (skip-require-clauses buffer start name)
+(define (skip-require-clauses buffer start)
+  (let loop ((start start))
+    (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
+      (if (looking-at "(require " sexp-start buffer)
+          (loop sexp-end)
+          start))))
+
+
+(define (find-best-require-clause buffer start name)
   (let loop ((start start) (needs-newline #t))
     (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
       (if (looking-at "(require " sexp-start buffer)
@@ -93,6 +101,21 @@
           (values start needs-newline)))))
 
 
+(define (find-best-alias-clause buffer start insertion)
+  (let loop ((start start) (needs-newline #t))
+    (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
+      (if (looking-at "(define-alias " sexp-start buffer)
+          (let-values (((name-start name-end) (%forward-sexp sexp-start buffer)))
+            (let ((text (buffer-text name-start name-end buffer)))
+              (cond ((string=? insertion text)
+                     (values #f #f))
+                    ((string<? insertion text)
+                     (values sexp-start #f))
+                    (else
+                     (loop sexp-end #f)))))
+          (values start needs-newline)))))
+
+
 (define (first-non-comment-line-offset buffer)
   (let ((line 0))
     (try-finally
@@ -101,3 +124,72 @@
       #f)
     (line-offset line buffer)))
 
+
+(define (add-alias-clause #!optional (symbol (symbol-near-point)) (buffer (current-buffer)))
+  (let-values (((alias type) (compute-alias-info (symbol->string symbol))))
+    (when alias
+      (when type
+        (let* ((insertion (format #f "(define-alias <~a> <~a>)" alias type)))
+          (let-values (((point needs-newline-before) (find-best-alias-insertion-point insertion buffer)))
+            (when point
+              (let* ((line   (offset-line point buffer))
+                     (offset (line-offset line buffer)))
+                (when (< offset point)
+                  (try-finally
+                      (set! offset (line-offset (+ line 1) buffer))
+                    #f))
+                (insert-text (format #f "~a~a~%"  (if needs-newline-before "\n" "") insertion) offset buffer))))))
+      (let ((expander (make-symbol-expander (lambda (_) (format #f "<~a>" alias)))))
+        (expander)))))
+
+
+(define (find-best-alias-insertion-point insertion buffer)
+  (let* ((start (first-non-comment-line-offset buffer))
+         (start (skip-module-headers buffer start))
+         (start (skip-require-clauses buffer start)))
+    (find-best-alias-clause buffer start insertion)))
+
+
+(define (compute-alias-info symbol)
+  (define (already-aliased? symbol)
+    (and (not (member #\. (string->list symbol)))
+         (char=? #\< (string-ref symbol 0))
+         (char=? #\> (string-ref symbol (- (string-length symbol) 1)))))
+
+  (define (get-type symbol)
+    (let ((types (find-symbol-types symbol)))
+      (and (pair? types)
+           (choose-type types))))
+
+  (define (normalize-symbol symbol)
+    (let ((start (if (char=? #\< (string-ref symbol 0)) 1 0))
+          (end   (let ((end (- (string-length symbol) 1)))
+                   (if (char=? #\> (string-ref symbol end)) end (+ end 1)))))
+      (substring symbol start end)))
+
+  (define (type->alias type)
+    (let* ((chars (reverse (string->list type)))
+           (index (list-index (cut char=? #\. <>) chars)))
+      (list->string (reverse (if index (take chars index) chars)))))
+
+  (if (already-aliased? symbol)
+      (values #f #f)
+      (let* ((symbol     (normalize-symbol symbol))
+             (alias-info (precomputed-alias-info symbol)))
+        (if alias-info
+            alias-info
+            (let ((type (get-type symbol)))
+              (or (and type (values (type->alias (symbol->string type)) type))
+                  (values #f #f)))))))
+
+
+(define (precomputed-alias-info symbol)
+  (cond
+   ((or (string=? symbol "Object") (string=? symbol "java.lang.Object"))
+    (values "Object" #f))
+
+   ((or (string=? symbol "String") (string=? symbol "java.lang.String"))
+    (values "String" #f))
+
+   (else
+    #f)))

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -284,6 +284,12 @@
                description="Sends predefined code to the interpreter"
                categoryId="Scheme Editing"
                id="org.schemeway.plugins.schemescript.eval.fast9"/>
+      <command
+            categoryId="Scheme Editing"
+            description="Adds a define-alias clause"
+            id="org.schemeway.plugins.schemescript.code.addAlias"
+            name="Add alias">
+      </command>
       <command name="Add require"
                description="Adds a require clause"
                categoryId="Scheme Editing"
@@ -590,6 +596,12 @@
             contextId="org.eclipse.ui.globalScope"
             sequence="ALT+K 9"
             schemeId="org.eclipse.ui.defaultAcceleratorConfiguration" >
+      </key>
+      <key
+            commandId="org.schemeway.plugins.schemescript.code.addAlias"
+            contextId="org.schemeway.plugins.schemescript.schemeEditorScope"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="ALT+CTRL+SHIFT+A">
       </key>
       <key  commandId="org.schemeway.plugins.schemescript.code.addRequire"
             contextId="org.schemeway.plugins.schemescript.schemeEditorScope"

--- a/plugin/src/org/schemeway/plugins/schemescript/editor/SchemeEditorActionsFactory.java
+++ b/plugin/src/org/schemeway/plugins/schemescript/editor/SchemeEditorActionsFactory.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005 SchemeWay.com
- * 
+ *
  * This is free software. For terms and warranty disclaimer, see ./COPYING
  */
 package org.schemeway.plugins.schemescript.editor;
@@ -18,7 +18,7 @@ public final class SchemeEditorActionsFactory {
     private SchemeEditorActionsFactory() {
         // must not be instantiated
     }
-    
+
     public static void createActions(SchemeEditor editor, ISourceViewer sourceViewer) {
         IAction action = new ForwardSExpAction(editor, false);
         action.setActionDefinitionId(SchemeActionConstants.SEXP_FORWARD);
@@ -61,7 +61,7 @@ public final class SchemeEditorActionsFactory {
         action = new FormatAction(editor);
         action.setActionDefinitionId(SchemeActionConstants.SEXP_FORMAT);
         editor.setAction(SchemeActionConstants.SEXP_FORMAT, action);
-        
+
         action = new ExpandSelectionToSexpressions(editor);
         action.setActionDefinitionId(SchemeActionConstants.SEXP_EXPAND_SELECTION);
         editor.setAction(SchemeActionConstants.SEXP_EXPAND_SELECTION, action);
@@ -97,7 +97,7 @@ public final class SchemeEditorActionsFactory {
         action = new CompressSpacesAction(editor);
         action.setActionDefinitionId(SchemeActionConstants.COMPRESS_SPACES);
         editor.setAction(SchemeActionConstants.COMPRESS_SPACES, action);
-        
+
         action = new MoveRightParenForwardOneExpression(editor);
         action.setActionDefinitionId(SchemeActionConstants.MOVE_RPAREN_FORWARD);
         editor.setAction(SchemeActionConstants.MOVE_RPAREN_FORWARD, action);
@@ -117,7 +117,7 @@ public final class SchemeEditorActionsFactory {
         action = new JumpToDefinitionAction(editor);
         action.setActionDefinitionId(SchemeActionConstants.JUMP_DEF);
         editor.setAction(SchemeActionConstants.JUMP_DEF, action);
-        
+
         addSchemeAction(editor, "sexp.kill-next", "kill-next-sexp");
         addSchemeAction(editor, "sexp.kill-previous", "kill-previous-sexp");
         addSchemeAction(editor, "sexp.raise", "raise-sexp");
@@ -128,32 +128,34 @@ public final class SchemeEditorActionsFactory {
         addSchemeAction(editor, "sexp.slurp-forward", "forward-slurp-sexp");
         addSchemeAction(editor, "sexp.slurp-backward", "backward-slurp-sexp");
         addSchemeAction(editor, "comment.multiline", "comment-selection");
+
+        addSchemeAction(editor, "code.addAlias", "add-alias-clause");
+        addSchemeAction(editor, "code.addRequire", "add-require-clause");
         addSchemeAction(editor, "code.expandPackage", "expand-package");
         addSchemeAction(editor, "code.expandNamespace", "expand-namespace");
         addSchemeAction(editor, "code.expandTypename", "expand-typename");
-        addSchemeAction(editor, "code.addRequire", "add-require-clause");
-        
+
         addSchemeAction(editor, "sexp.rename-symbol", "rename-symbol");
         addSchemeAction(editor, "sexp.rename-symbol-locally", "rename-symbol-locally");
         addSchemeAction(editor, "sexp.rename-symbol-in-file", "rename-symbol-in-file");
         addSchemeAction(editor, "sexp.extract-variable", "extract-variable");
         addSchemeAction(editor, "sexp.create-function", "create-function-from-expression");
-        
+
         action = new TextOperationAction(SchemeScriptPlugin.getDefault().getResourceBundle(),
-                                         "ContentAssistProposal.", editor, ISourceViewer.CONTENTASSIST_PROPOSALS); //$NON-NLS-1$
+                "ContentAssistProposal.", editor, ISourceViewer.CONTENTASSIST_PROPOSALS); //$NON-NLS-1$
         action.setActionDefinitionId(ITextEditorActionDefinitionIds.CONTENT_ASSIST_PROPOSALS);
         editor.setAction("ContentAssistProposal", action);
 
         action = new TextOperationAction(SchemeScriptPlugin.getDefault().getResourceBundle(),
-                                         "ContentAssistTip.", editor, ISourceViewer.CONTENTASSIST_CONTEXT_INFORMATION); //$NON-NLS-1$
+                "ContentAssistTip.", editor, ISourceViewer.CONTENTASSIST_CONTEXT_INFORMATION); //$NON-NLS-1$
         action.setActionDefinitionId(ITextEditorActionDefinitionIds.CONTENT_ASSIST_CONTEXT_INFORMATION);
         editor.setAction("ContentAssistTip", action);
     }
-    
+
     private static void addSchemeAction(SchemeEditor editor, String idSuffix, String procedureName) {
-    	IAction action = new SchemeProcedureAction(procedureName);
-    	String id = SchemeScriptPlugin.PLUGIN_NS + "." + idSuffix;
-    	action.setActionDefinitionId(id);
-    	editor.setAction(id, action);
+        IAction action = new SchemeProcedureAction(procedureName);
+        String id = SchemeScriptPlugin.PLUGIN_NS + "." + idSuffix;
+        action.setActionDefinitionId(id);
+        editor.setAction(id, action);
     }
 }


### PR DESCRIPTION
The command will create a `define-alias` for the current symbol if required (i.e. there is not already a `define-alias` for the same type)

The command will also change the current symbol to the alias value. So, the command can be used to convert fully-qualified class name to an existing alias.

The types `Object` and `String` never trigger a define-alias addition and the fully qualified name for those types are converted to their simple class name (running the command on symbol `<java.lang.String>` will result in `<String>` and no `define-alias`).
