### PR TITLE
Feature private alias preferences

### DIFF
--- a/plugin/conf/foreign.scm
+++ b/plugin/conf/foreign.scm
@@ -30,7 +30,7 @@
 (define-namespace SchemePlugin     "class:org.schemeway.plugins.schemescript.SchemeScriptPlugin")
 (define-namespace SchemeIndentationContext "class:org.schemeway.plugins.schemescript.indentation.SchemeIndentationContext")
 (define-namespace FormatAction     "class:org.schemeway.plugins.schemescript.action.FormatAction")
-
+(define-namespace ActionPreferences "class:org.schemeway.plugins.schemescript.preferences.ActionPreferences")
 
 (define-namespace JavaCore         "class:org.eclipse.jdt.core.JavaCore")
 (define-namespace IJavaModel       "class:org.eclipse.jdt.core.IJavaModel")

--- a/plugin/conf/modules.scm
+++ b/plugin/conf/modules.scm
@@ -115,10 +115,10 @@
 
 
 (define (find-best-alias-clause buffer start insertion)
-  (let ((binding (if (use-private-alias?) "define-private-alias" "define-alias")))
+  (let ((sexp-prefix (format #f "(~a " (if (use-private-alias?) "define-private-alias" "define-alias"))))
     (let loop ((start start) (needs-newline #t))
       (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
-        (if (looking-at (format #f "(~a " binding) sexp-start buffer)
+        (if (looking-at sexp-prefix sexp-start buffer)
             (let-values (((name-start name-end) (%forward-sexp sexp-start buffer)))
               (let ((text (buffer-text name-start name-end buffer)))
                 (cond ((string=? insertion text)

--- a/plugin/conf/modules.scm
+++ b/plugin/conf/modules.scm
@@ -46,6 +46,10 @@
            (choose-from-list "Symbol multiply declared" "Choose the module to require:" entries)))))
 
 
+(define (use-private-alias?)
+  (ActionPreferences:usePrivateAlias))
+
+
 (define (add-require-clause #!optional (symbol (symbol-near-point)) (buffer (current-buffer)))
   (let ((modulename (symbol->module-name symbol buffer)))
     (when modulename
@@ -73,7 +77,8 @@
       (if (or (looking-at "(module-name " sexp-start buffer)
               (looking-at "(module-static " sexp-start buffer)
               (looking-at "(module-extends " sexp-start buffer)
-              (looking-at "(module-export " sexp-start buffer))
+              (looking-at "(module-export " sexp-start buffer)
+              (looking-at "(module-compile-options " sexp-start buffer))
           (loop sexp-end)
           start))))
 
@@ -82,6 +87,14 @@
   (let loop ((start start))
     (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
       (if (looking-at "(require " sexp-start buffer)
+          (loop sexp-end)
+          start))))
+
+
+(define (skip-define-alias-clauses buffer start)
+  (let loop ((start start))
+    (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
+      (if (looking-at "(define-alias " sexp-start buffer)
           (loop sexp-end)
           start))))
 
@@ -102,18 +115,19 @@
 
 
 (define (find-best-alias-clause buffer start insertion)
-  (let loop ((start start) (needs-newline #t))
-    (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
-      (if (looking-at "(define-alias " sexp-start buffer)
-          (let-values (((name-start name-end) (%forward-sexp sexp-start buffer)))
-            (let ((text (buffer-text name-start name-end buffer)))
-              (cond ((string=? insertion text)
-                     (values #f #f))
-                    ((string<? insertion text)
-                     (values sexp-start #f))
-                    (else
-                     (loop sexp-end #f)))))
-          (values start needs-newline)))))
+  (let ((binding (if (use-private-alias?) "define-private-alias" "define-alias")))
+    (let loop ((start start) (needs-newline #t))
+      (let-values (((sexp-start sexp-end) (%forward-sexp start buffer)))
+        (if (looking-at (format #f "(~a " binding) sexp-start buffer)
+            (let-values (((name-start name-end) (%forward-sexp sexp-start buffer)))
+              (let ((text (buffer-text name-start name-end buffer)))
+                (cond ((string=? insertion text)
+                       (values #f #f))
+                      ((string<? insertion text)
+                       (values sexp-start #f))
+                      (else
+                       (loop sexp-end #f)))))
+            (values start needs-newline))))))
 
 
 (define (first-non-comment-line-offset buffer)
@@ -129,7 +143,8 @@
   (let-values (((alias type) (compute-alias-info (symbol->string symbol))))
     (when alias
       (when type
-        (let* ((insertion (format #f "(define-alias <~a> <~a>)" alias type)))
+        (let* ((binding   (if (use-private-alias?) "define-private-alias" "define-alias"))
+               (insertion (format #f "(~a <~a> <~a>)" binding alias type)))
           (let-values (((point needs-newline-before) (find-best-alias-insertion-point insertion buffer)))
             (when point
               (let* ((line   (offset-line point buffer))
@@ -146,7 +161,10 @@
 (define (find-best-alias-insertion-point insertion buffer)
   (let* ((start (first-non-comment-line-offset buffer))
          (start (skip-module-headers buffer start))
-         (start (skip-require-clauses buffer start)))
+         (start (skip-require-clauses buffer start))
+         (start (if (use-private-alias?)
+                    (skip-define-alias-clauses buffer start)
+                    start)))
     (find-best-alias-clause buffer start insertion)))
 
 

--- a/plugin/plugin.xml
+++ b/plugin/plugin.xml
@@ -727,6 +727,12 @@
             class="org.schemeway.plugins.schemescript.preferences.RemoteInterpreterPreferences"
             id="org.schemeway.plugins.schemescript.preferences.interpreter.remoteInterpreter"
             name="Remote Interpreter"/>
+      <page
+            category="org.schemeway.plugins.schemescript.preferences.scheme"
+            class="org.schemeway.plugins.schemescript.preferences.ActionPreferences"
+            id="org.schemeway.plugins.schemescript.preferences.action"
+            name="Action">
+      </page>
    </extension>
    <extension
          point="org.eclipse.help.toc">

--- a/plugin/src/org/schemeway/plugins/schemescript/preferences/ActionPreferences.java
+++ b/plugin/src/org/schemeway/plugins/schemescript/preferences/ActionPreferences.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2004 Nu Echo Inc.
+ *
+ * This is free software. For terms and warranty disclaimer, see ./COPYING
+ */
+package org.schemeway.plugins.schemescript.preferences;
+
+import org.eclipse.jface.preference.*;
+import org.eclipse.swt.*;
+import org.eclipse.swt.layout.*;
+import org.eclipse.swt.widgets.*;
+import org.schemeway.plugins.schemescript.*;
+
+public class ActionPreferences extends SchemePreferencePage {
+    public final static String PREFIX = SchemeScriptPlugin.PLUGIN_NS + ".action.";
+    public final static String ACTION_PRIVATE_ALIAS = PREFIX + "private-alias";
+
+    public static void initializeDefaults(IPreferenceStore store) {
+        store.setDefault(ACTION_PRIVATE_ALIAS, false);
+    }
+
+    public static boolean usePrivateAlias() {
+        IPreferenceStore store = SchemeScriptPlugin.getDefault().getPreferenceStore();
+
+        return store.getBoolean(ActionPreferences.ACTION_PRIVATE_ALIAS);
+    }
+
+    private Button mPrivateAlias;
+
+    @Override
+    protected Control createContents(Composite parent) {
+        Composite composite = new Composite(parent, SWT.NONE);
+        composite.setLayout(new GridLayout(1, false));
+
+        createCommandsSection(composite);
+
+        initializeValues();
+        return composite;
+    }
+
+    private void createCommandsSection(Composite parent) {
+        Group group = new Group(parent, SWT.NONE);
+        group.setText("Commands");
+        group.setLayout(new GridLayout(1, false));
+        group.setLayoutData(new GridData(GridData.FILL_HORIZONTAL | GridData.VERTICAL_ALIGN_BEGINNING));
+
+        mPrivateAlias = new Button(group, SWT.CHECK);
+        mPrivateAlias.setText("Add define-alias command inserts define-private-alias");
+    }
+
+    @Override
+    protected IPreferenceStore doGetPreferenceStore() {
+        return SchemeScriptPlugin.getDefault().getPreferenceStore();
+    }
+
+    @Override
+    protected void doPerformDefaults() {
+        IPreferenceStore store = getPreferenceStore();
+
+        mPrivateAlias.setSelection(store.getDefaultBoolean(ACTION_PRIVATE_ALIAS));
+    }
+
+    @Override
+    protected void initializeValues() {
+        IPreferenceStore store = getPreferenceStore();
+
+        mPrivateAlias.setSelection(store.getBoolean(ACTION_PRIVATE_ALIAS));
+    }
+
+    @Override
+    protected void storeValues() {
+        IPreferenceStore store = getPreferenceStore();
+
+        store.setValue(ACTION_PRIVATE_ALIAS, mPrivateAlias.getSelection());
+    }
+}

--- a/plugin/src/org/schemeway/plugins/schemescript/preferences/SyntaxPreferences.java
+++ b/plugin/src/org/schemeway/plugins/schemescript/preferences/SyntaxPreferences.java
@@ -34,12 +34,12 @@ public class SyntaxPreferences extends SchemePreferencePage {
         public ListViewer viewer;
         public Text reTextbox;
 
-    	public SyntaxCategoryWidgets(List list, Text textbox, ListViewer listViewer) {
-			super();
-			this.listbox = list;
-			viewer = listViewer;
-			reTextbox = textbox;
-		}
+        public SyntaxCategoryWidgets(List list, Text textbox, ListViewer listViewer) {
+            super();
+            this.listbox = list;
+            viewer = listViewer;
+            reTextbox = textbox;
+        }
     }
 
     private SyntaxCategoryWidgets mDefineWidgets;
@@ -152,7 +152,7 @@ public class SyntaxPreferences extends SchemePreferencePage {
     }
 
     private SyntaxCategoryWidgets createListControl(TabFolder folder, String tabName, String toolTip) {
-    	GridData data;
+        GridData data;
 
         TabItem item = new TabItem(folder, SWT.NULL);
         item.setText(tabName);
@@ -240,19 +240,19 @@ public class SyntaxPreferences extends SchemePreferencePage {
         reText.setLayoutData(data);
 
         reText.addKeyListener(new KeyAdapter() {
-        	@Override
+            @Override
             public void keyReleased(KeyEvent e) {
-        		String eventText = reText.getText();
-        		try {
-        			Pattern.compile(eventText);
-        			setValid(true);
-        			setErrorMessage(null);
-        		}
-        		catch (PatternSyntaxException exception) {
-        			setValid(false);
-        			setErrorMessage("Invalid regular expression");
-        		}
-        	}
+                String eventText = reText.getText();
+                try {
+                    Pattern.compile(eventText);
+                    setValid(true);
+                    setErrorMessage(null);
+                }
+                catch (PatternSyntaxException exception) {
+                    setValid(false);
+                    setErrorMessage("Invalid regular expression");
+                }
+            }
         });
 
         return new SyntaxCategoryWidgets(list, reText, listViewer);
@@ -303,20 +303,20 @@ public class SyntaxPreferences extends SchemePreferencePage {
 
     @Override
     protected void storeValues() {
-    	KeywordManager manager = SchemeScriptPlugin.getDefault().getTextTools().getKeywordManager();
+        KeywordManager manager = SchemeScriptPlugin.getDefault().getTextTools().getKeywordManager();
 
-    	manager.clear();
-    	manager.setDefines(mDefineWidgets.listbox.getItems());
-    	manager.setDefineRegularExpression(mDefineWidgets.reTextbox.getText());
-    	manager.setConstants(mConstantWidgets.listbox.getItems());
-    	manager.setConstantRegularExpression(mConstantWidgets.reTextbox.getText());
-    	manager.setKeywords(mKeywordWidgets.listbox.getItems());
-    	manager.setKeywordRegularExpression(mKeywordWidgets.reTextbox.getText());
-    	manager.setMutators(mMutatorWidgets.listbox.getItems());
-    	manager.setMutatorRegularExpression(mMutatorWidgets.reTextbox.getText());
-    	manager.setSpecials(mSpecialWidgets.listbox.getItems());
-    	manager.setSpecialRegularExpression(mSpecialWidgets.reTextbox.getText());
-    	manager.saveValues();
+        manager.clear();
+        manager.setDefines(mDefineWidgets.listbox.getItems());
+        manager.setDefineRegularExpression(mDefineWidgets.reTextbox.getText());
+        manager.setConstants(mConstantWidgets.listbox.getItems());
+        manager.setConstantRegularExpression(mConstantWidgets.reTextbox.getText());
+        manager.setKeywords(mKeywordWidgets.listbox.getItems());
+        manager.setKeywordRegularExpression(mKeywordWidgets.reTextbox.getText());
+        manager.setMutators(mMutatorWidgets.listbox.getItems());
+        manager.setMutatorRegularExpression(mMutatorWidgets.reTextbox.getText());
+        manager.setSpecials(mSpecialWidgets.listbox.getItems());
+        manager.setSpecialRegularExpression(mSpecialWidgets.reTextbox.getText());
+        manager.saveValues();
     }
 
     private void addEntry(final Text text, final Button addButton, final ListViewer listViewer) {

--- a/plugin/src/org/schemeway/plugins/schemescript/preferences/SyntaxPreferences.java
+++ b/plugin/src/org/schemeway/plugins/schemescript/preferences/SyntaxPreferences.java
@@ -34,12 +34,12 @@ public class SyntaxPreferences extends SchemePreferencePage {
         public ListViewer viewer;
         public Text reTextbox;
 
-        public SyntaxCategoryWidgets(List list, Text textbox, ListViewer listViewer) {
-            super();
-            this.listbox = list;
-            viewer = listViewer;
-            reTextbox = textbox;
-        }
+    	public SyntaxCategoryWidgets(List list, Text textbox, ListViewer listViewer) {
+			super();
+			this.listbox = list;
+			viewer = listViewer;
+			reTextbox = textbox;
+		}
     }
 
     private SyntaxCategoryWidgets mDefineWidgets;
@@ -70,6 +70,7 @@ public class SyntaxPreferences extends SchemePreferencePage {
                 "define-record-type",
                 "define-unit",
                 "define-alias",
+                "define-private-alias",
                 "define-base-unit"
     };
     private final static String[] DEFAULT_KEYWORDS = new String[] {
@@ -125,6 +126,7 @@ public class SyntaxPreferences extends SchemePreferencePage {
                 "#!eof", "#!null", "#!void"
     };
 
+    @Override
     protected Control createContents(Composite parent) {
         Composite composite = new Composite(parent, SWT.NONE);
         GridLayout layout = new GridLayout();
@@ -150,7 +152,7 @@ public class SyntaxPreferences extends SchemePreferencePage {
     }
 
     private SyntaxCategoryWidgets createListControl(TabFolder folder, String tabName, String toolTip) {
-        GridData data;
+    	GridData data;
 
         TabItem item = new TabItem(folder, SWT.NULL);
         item.setText(tabName);
@@ -199,12 +201,14 @@ public class SyntaxPreferences extends SchemePreferencePage {
         listViewer.setSorter(new ViewerSorter());
 
         list.addSelectionListener(new SelectionAdapter() {
+            @Override
             public void widgetSelected(SelectionEvent event) {
                 deleteButton.setEnabled(list.getSelectionCount() > 0);
             }
         });
 
         text.addKeyListener(new KeyAdapter() {
+            @Override
             public void keyReleased(KeyEvent event) {
                 String symbol = text.getText();
                 addButton.setEnabled(SchemeScannerUtilities.isIdentifier(symbol) && (list.indexOf(symbol) == -1));
@@ -212,12 +216,14 @@ public class SyntaxPreferences extends SchemePreferencePage {
         });
 
         addButton.addSelectionListener(new SelectionAdapter() {
+            @Override
             public void widgetSelected(SelectionEvent event) {
                 addEntry(text, addButton, listViewer);
             }
         });
 
         deleteButton.addSelectionListener(new SelectionAdapter() {
+            @Override
             public void widgetSelected(SelectionEvent event) {
                 list.remove(list.getSelectionIndices());
             }
@@ -234,23 +240,25 @@ public class SyntaxPreferences extends SchemePreferencePage {
         reText.setLayoutData(data);
 
         reText.addKeyListener(new KeyAdapter() {
+        	@Override
             public void keyReleased(KeyEvent e) {
-                String eventText = reText.getText();
-                try {
-                    Pattern.compile(eventText);
-                    setValid(true);
-                    setErrorMessage(null);
-                }
-                catch (PatternSyntaxException exception) {
-                    setValid(false);
-                    setErrorMessage("Invalid regular expression");
-                }
-            }
+        		String eventText = reText.getText();
+        		try {
+        			Pattern.compile(eventText);
+        			setValid(true);
+        			setErrorMessage(null);
+        		}
+        		catch (PatternSyntaxException exception) {
+        			setValid(false);
+        			setErrorMessage("Invalid regular expression");
+        		}
+        	}
         });
 
         return new SyntaxCategoryWidgets(list, reText, listViewer);
     }
 
+    @Override
     protected void doPerformDefaults() {
         mDefineWidgets.viewer.setInput(DEFAULT_DEFINES);
         mDefineWidgets.reTextbox.setText("");
@@ -277,6 +285,7 @@ public class SyntaxPreferences extends SchemePreferencePage {
         store.setDefault(SYNTAX_CONSTANT_RE, "");
     }
 
+    @Override
     protected void initializeValues() {
         KeywordManager manager = SchemeScriptPlugin.getDefault().getTextTools().getKeywordManager();
         mDefineWidgets.viewer.setInput(manager.getDefines());
@@ -292,21 +301,22 @@ public class SyntaxPreferences extends SchemePreferencePage {
 
     }
 
+    @Override
     protected void storeValues() {
-        KeywordManager manager = SchemeScriptPlugin.getDefault().getTextTools().getKeywordManager();
+    	KeywordManager manager = SchemeScriptPlugin.getDefault().getTextTools().getKeywordManager();
 
-        manager.clear();
-        manager.setDefines(mDefineWidgets.listbox.getItems());
-        manager.setDefineRegularExpression(mDefineWidgets.reTextbox.getText());
-        manager.setConstants(mConstantWidgets.listbox.getItems());
-        manager.setConstantRegularExpression(mConstantWidgets.reTextbox.getText());
-        manager.setKeywords(mKeywordWidgets.listbox.getItems());
-        manager.setKeywordRegularExpression(mKeywordWidgets.reTextbox.getText());
-        manager.setMutators(mMutatorWidgets.listbox.getItems());
-        manager.setMutatorRegularExpression(mMutatorWidgets.reTextbox.getText());
-        manager.setSpecials(mSpecialWidgets.listbox.getItems());
-        manager.setSpecialRegularExpression(mSpecialWidgets.reTextbox.getText());
-        manager.saveValues();
+    	manager.clear();
+    	manager.setDefines(mDefineWidgets.listbox.getItems());
+    	manager.setDefineRegularExpression(mDefineWidgets.reTextbox.getText());
+    	manager.setConstants(mConstantWidgets.listbox.getItems());
+    	manager.setConstantRegularExpression(mConstantWidgets.reTextbox.getText());
+    	manager.setKeywords(mKeywordWidgets.listbox.getItems());
+    	manager.setKeywordRegularExpression(mKeywordWidgets.reTextbox.getText());
+    	manager.setMutators(mMutatorWidgets.listbox.getItems());
+    	manager.setMutatorRegularExpression(mMutatorWidgets.reTextbox.getText());
+    	manager.setSpecials(mSpecialWidgets.listbox.getItems());
+    	manager.setSpecialRegularExpression(mSpecialWidgets.reTextbox.getText());
+    	manager.saveValues();
     }
 
     private void addEntry(final Text text, final Button addButton, final ListViewer listViewer) {


### PR DESCRIPTION
With the introduction of define-private-alias, I added a preference setting that when check, define-private-alias is used instead of define-alias in the Add define-alias command.
