### PR TITLE
Implement support for R6RS inline escapes

### DIFF
--- a/plugin/src/org/schemeway/plugins/schemescript/editor/SchemePartitionScanner.java
+++ b/plugin/src/org/schemeway/plugins/schemescript/editor/SchemePartitionScanner.java
@@ -29,7 +29,7 @@ public class SchemePartitionScanner implements IPartitionTokenScanner {
 	private static final int STATE_ESCAPE = 4;
 	private static final int STATE_SHARP_LT = 5;
 	private static final int STATE_DONE = 6;
-    private static final int STATE_INLINE_HEX_ESCAPE = 7;
+	private static final int STATE_INLINE_HEX_ESCAPE = 7;
 
 	private IDocument mDocument;
 	private int mEnd;


### PR DESCRIPTION
R6RS identifiers can contain any character by virtue of using an "inline escape".  These inline escapes contain a semicolon, which confuses the ShemeWay scanner and partitioner.  This patch prevents the semicolon in an inline escape from being treated as the start of a comment.

http://www.r6rs.org/final/html/r6rs/r6rs-Z-H-7.html#node_sec_4.2.4
